### PR TITLE
fix:when client deprecate eof packet, should write ok packet instead

### DIFF
--- a/pkg/mysql/server.go
+++ b/pkg/mysql/server.go
@@ -531,7 +531,11 @@ func (l *Listener) ExecuteCommand(c *Conn, ctx *proto.Context) error {
 			if err != nil {
 				return err
 			}
-			return c.writeEOFPacket(c.StatusFlags, warn)
+			if err := c.writeEndResult(l.capabilities, false, 0, 0, warn); err != nil {
+				log.Errorf("Error writing result to %s: %v", c, err)
+				return err
+			}
+			return nil
 		}()
 		if err != nil {
 			return err
@@ -657,7 +661,11 @@ func (l *Listener) ExecuteCommand(c *Conn, ctx *proto.Context) error {
 			if err != nil {
 				return err
 			}
-			return c.writeEOFPacket(c.StatusFlags, warn)
+			if err := c.writeEndResult(l.capabilities, false, 0, 0, warn); err != nil {
+				log.Errorf("Error writing result to %s: %v", c, err)
+				return err
+			}
+			return nil
 		}()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #44

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```