### PR TITLE
fix: client exit ,but do not send com_quit

### DIFF
--- a/pkg/mysql/server.go
+++ b/pkg/mysql/server.go
@@ -192,7 +192,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		c.sequence = 0
 		data, err := c.readEphemeralPacket()
 		if err != nil {
-			c.recycleReadPacket()
+			// Don't log EOF errors. They cause too much spam.
+			if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+				log.Errorf("Error reading packet from %s: %v", c, err)
+			}
 			return
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

客户端发送请求后，并没有发送com_quit包，就直接发FIN要关闭连接了
这时候，arana依然处于一个readPacket的状态，先解析接收到包的header，但是读取到EOF，返回了错误，这里直接panic掉了(此时arana，并不知道客户端是不是出了问题)。当arana在处理server端协议的时候，遇到EOF，打日志，不报panic

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #58 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```